### PR TITLE
Support for reading stdin

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,7 @@ var argv = require('yargs')
       describe: 'Diff input source',
       nargs: 1,
       type: 'string',
-      choices: ['file', 'command'],
+      choices: ['file', 'command', 'stdin'],
       default: 'command'
     }
   })
@@ -93,6 +93,8 @@ var argv = require('yargs')
 function getInput() {
   if (argv.input === 'file') {
     return readFile(argv._[0]);
+  } else if (argv.input === 'stdin') {
+      return readFile('/dev/stdin');
   } else {
     var gitArgs;
     if (argv._.length && argv._[0]) {


### PR DESCRIPTION
This way we can pipe commands like this:

```
git show HEAD~5 | diff2html -i stdin
```

This is very useful for targeting specific commits and showing them. Your library is capable of reading `git show` output too, and is very common in my team to discuss a specific commit, not only diffs.

One drawback is that I think Windows is not supported this way. I'll be looking on how to improve the read from stdin in a way that is compatible with windows too (seems like is not that easy to read from stdin in node hehe).

Let me know your thoughts!

Cheers
