### PR TITLE
Fix usage as a local dependency

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -98,10 +98,12 @@
     var templatePath = path.resolve(__dirname, '..', 'dist', 'template.html');
     var template = utils.readFileSync(templatePath);
 
-    var cssFilePath = path.resolve(__dirname, '..', 'node_modules', 'diff2html', 'dist', 'diff2html.min.css');
+    var diff2htmlPath = path.join(path.dirname(require.resolve('diff2html')), '..');
+
+    var cssFilePath = path.resolve(diff2htmlPath, 'dist', 'diff2html.min.css');
     var cssContent = utils.readFileSync(cssFilePath);
 
-    var jsUiFilePath = path.resolve(__dirname, '..', 'node_modules', 'diff2html', 'dist', 'diff2html-ui.min.js');
+    var jsUiFilePath = path.resolve(diff2htmlPath, 'dist', 'diff2html-ui.min.js');
     var jsUiContent = utils.readFileSync(jsUiFilePath);
 
     return template


### PR DESCRIPTION
With this changes diff2html-cli supports local dependency style of usage.
Example:
1 - install package locally

```
npm i -D diff2html-cli
```

2 - add a script to `package.json`:

```
scripts: {
  'show-diff': 'diff2html -- -M HEAD~1'
}
```

3 - then run in console

```
npm run show-diff
```
