### PR TITLE
Custom HTML templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Diff to Html generates pretty HTML diffs from unified and git diff output in you
       --lm, --matching                  Diff line matching type   [choices: "lines", "words", "none"] [default: "none"]
       --lmt, --matchWordsThreshold      Diff line matching word threshold   [default: "0.25"]
       --lmm, --matchingMaxComparisons   Diff line matching maximum line comparisons of a block of changes [default: 2500]
+      --hwt, --htmlWrapperTemplate      Path to custom template to be rendered when using the "html" output format [string]
       -f, --format                      Output format   [choices: "html", "json"] [default: "html"]
       -d, --diff                        Diff style   [choices: "word", "char"] [default: "word"]
       -i, --input                       Diff input source   [choices: "file", "command", "stdin"] [default: "command"]
       -o, --output                      Output destination   [choices: "preview", "stdout"] [default: "preview"]
       -u, --diffy                       Upload to diffy.org   [choices: "browser", "pbcopy", "print"]
       -F, --file                        Send output to file (overrides output option)   [string]
-      -hwt, --html-wrapper-template     Path to custom template to be rendered when using the "html" output format [string]
       --version                         Show version number
       -h, --help                        Show help
 
@@ -85,7 +85,7 @@ Diff to Html generates pretty HTML diffs from unified and git diff output in you
           -> print json format to stdout
       diff2html -F my-pretty-diff.html -- -M HEAD~1
           ->  print to file
-      diff2html -F my-pretty-diff.html -hwt my-custom-template.html -- -M HEAD~1
+      diff2html -F my-pretty-diff.html --hwt my-custom-template.html -- -M HEAD~1
           ->  print to file using custom markup
               templates can include the following variables:
                 `<!--diff2html-css-->` - writes default CSS to page

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Diff to Html generates pretty HTML diffs from unified and git diff output in you
       -o, --output                      Output destination   [choices: "preview", "stdout"] [default: "preview"]
       -u, --diffy                       Upload to diffy.org   [choices: "browser", "pbcopy", "print"]
       -F, --file                        Send output to file (overrides output option)   [string]
-      -w, --html-wrapper-template       Path to custom template to be rendered when using the "html" output format [string]
+      -hwt, --html-wrapper-template       Path to custom template to be rendered when using the "html" output format [string]
       --version                         Show version number
       -h, --help                        Show help
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Diff to Html generates pretty HTML diffs from unified and git diff output in you
           -> print json format to stdout
       diff2html -F my-pretty-diff.html -- -M HEAD~1
           ->  print to file
-      diff2html -F my-pretty-diff.html -w my-custom-template.html -- -M HEAD~1
+      diff2html -F my-pretty-diff.html -hwt my-custom-template.html -- -M HEAD~1
           ->  print to file using custom markup
               templates can include the following variables:
                 `<!--diff2html-css-->` - writes default CSS to page

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Diff to Html generates pretty HTML diffs from unified and git diff output in you
       -o, --output                      Output destination   [choices: "preview", "stdout"] [default: "preview"]
       -u, --diffy                       Upload to diffy.org   [choices: "browser", "pbcopy", "print"]
       -F, --file                        Send output to file (overrides output option)   [string]
+      -t, --template                    Path to custom template to be rendered when using the "html" output format [string]
       --version                         Show version number
       -h, --help                        Show help
 
@@ -84,6 +85,14 @@ Diff to Html generates pretty HTML diffs from unified and git diff output in you
           -> print json format to stdout
       diff2html -F my-pretty-diff.html -- -M HEAD~1
           ->  print to file
+      diff2html -F my-pretty-diff.html -t my-custom-template.html -- -M HEAD~1
+          ->  print to file using custom markup
+              templates can include the following variables:
+                `<!--diff2html-css-->` - writes default CSS to page
+                `<!--diff2html-js-ui-->` - writes default JavaScript UI scripts to page
+                `//diff2html-fileListCloseable` - writes code to support selected list interaction, must be within a <script> block
+                `//diff2html-synchronisedScroll` - writes code to support selected scroll interaction, must be within a <script> block
+                `/<!--diff2html-diff-->` - writes diff content to page
 
     © 2014-2016 rtfpessoa
     For support, check out https://github.com/rtfpessoa/diff2html-cli

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Diff to Html generates pretty HTML diffs from unified and git diff output in you
                 `<!--diff2html-js-ui-->` - writes default JavaScript UI scripts to page
                 `//diff2html-fileListCloseable` - writes code to support selected list interaction, must be within a <script> block
                 `//diff2html-synchronisedScroll` - writes code to support selected scroll interaction, must be within a <script> block
-                `/<!--diff2html-diff-->` - writes diff content to page
+                `<!--diff2html-diff-->` - writes diff content to page
 
     © 2014-2016 rtfpessoa
     For support, check out https://github.com/rtfpessoa/diff2html-cli

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Diff to Html generates pretty HTML diffs from unified and git diff output in you
       -o, --output                      Output destination   [choices: "preview", "stdout"] [default: "preview"]
       -u, --diffy                       Upload to diffy.org   [choices: "browser", "pbcopy", "print"]
       -F, --file                        Send output to file (overrides output option)   [string]
-      -hwt, --html-wrapper-template       Path to custom template to be rendered when using the "html" output format [string]
+      -hwt, --html-wrapper-template     Path to custom template to be rendered when using the "html" output format [string]
       --version                         Show version number
       -h, --help                        Show help
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Diff to Html generates pretty HTML diffs from unified and git diff output in you
       -o, --output                      Output destination   [choices: "preview", "stdout"] [default: "preview"]
       -u, --diffy                       Upload to diffy.org   [choices: "browser", "pbcopy", "print"]
       -F, --file                        Send output to file (overrides output option)   [string]
-      -t, --template                    Path to custom template to be rendered when using the "html" output format [string]
+      -w, --html-wrapper-template       Path to custom template to be rendered when using the "html" output format [string]
       --version                         Show version number
       -h, --help                        Show help
 
@@ -85,7 +85,7 @@ Diff to Html generates pretty HTML diffs from unified and git diff output in you
           -> print json format to stdout
       diff2html -F my-pretty-diff.html -- -M HEAD~1
           ->  print to file
-      diff2html -F my-pretty-diff.html -t my-custom-template.html -- -M HEAD~1
+      diff2html -F my-pretty-diff.html -w my-custom-template.html -- -M HEAD~1
           ->  print to file using custom markup
               templates can include the following variables:
                 `<!--diff2html-css-->` - writes default CSS to page

--- a/src/cli.js
+++ b/src/cli.js
@@ -70,7 +70,7 @@
     var defaultTemplate = path.resolve(__dirname, '..', 'dist', 'template.html');
     config.wordByWord = (baseConfig.diff === 'word');
     config.charByChar = (baseConfig.diff === 'char');
-    config.template = baseConfig.template || defaultTemplate;
+    config.template = baseConfig.htmlWrapperTemplate || defaultTemplate;
 
     if (!fs.existsSync(config.template)) {
       return callback(new Error('Template (`' + baseConfig.template + '`) not found!'));

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,7 @@
  */
 
 (function() {
+  var fs = require('fs');
   var os = require('os');
   var path = require('path');
 
@@ -66,8 +67,14 @@
   Diff2HtmlInterface.prototype.getOutput = function(baseConfig, input, callback) {
     var that = this;
     var config = baseConfig;
+    var defaultTemplate = path.resolve(__dirname, '..', 'dist', 'template.html');
     config.wordByWord = (baseConfig.diff === 'word');
     config.charByChar = (baseConfig.diff === 'char');
+    config.template = baseConfig.template || defaultTemplate;
+
+    if (!fs.existsSync(config.template)) {
+      return callback(new Error('Template (`' + baseConfig.template + '`) not found!'));
+    }
 
     var jsonContent = diff2Html.getJsonFromDiff(input, config);
 
@@ -99,7 +106,7 @@
   };
 
   Diff2HtmlInterface.prototype._prepareHTML = function(content, config) {
-    var templatePath = path.resolve(__dirname, '..', 'dist', 'template.html');
+    var templatePath = config.template;
     var template = utils.readFileSync(templatePath);
 
     var diff2htmlPath = path.join(path.dirname(require.resolve('diff2html')), '..');

--- a/src/main.js
+++ b/src/main.js
@@ -130,8 +130,8 @@ var argv = yargs.usage('Usage: diff2html [options] -- [diff args]')
     }
   })
   .options({
-    't': {
-      alias: 'template',
+    'w': {
+      alias: 'html-wrapper-template',
       describe: 'Use a custom template when generating markup',
       nargs: 1,
       type: 'string'

--- a/src/main.js
+++ b/src/main.js
@@ -129,6 +129,14 @@ var argv = yargs.usage('Usage: diff2html [options] -- [diff args]')
       type: 'string'
     }
   })
+  .options({
+    't': {
+      alias: 'template',
+      describe: 'Use a custom template when generating markup',
+      nargs: 1,
+      type: 'string'
+    }
+  })
   .example('diff2html -s line -f html -d word -i command -o preview -- -M HEAD~1',
     'diff last commit, line by line, word comparison between lines,' +
     'previewed in the browser and input from git diff command')

--- a/src/main.js
+++ b/src/main.js
@@ -130,7 +130,7 @@ var argv = yargs.usage('Usage: diff2html [options] -- [diff args]')
     }
   })
   .options({
-    'w': {
+    'hwt': {
       alias: 'html-wrapper-template',
       describe: 'Use a custom template when generating markup',
       nargs: 1,

--- a/src/main.js
+++ b/src/main.js
@@ -131,7 +131,7 @@ var argv = yargs.usage('Usage: diff2html [options] -- [diff args]')
   })
   .options({
     'hwt': {
-      alias: 'html-wrapper-template',
+      alias: 'htmlWrapperTemplate',
       describe: 'Use a custom template when generating markup',
       nargs: 1,
       type: 'string'


### PR DESCRIPTION
Resolves #33 by allowing users to provide a path to a custom markup template when rendering output as html.  More specifically:

- updated `README.md` with a list of variables that can be used within a custom template
- updated `main.js` with the `-t, --template` option to use a custom html
- updated `cli.js` to use template set in user config, otherwise defaults to existing template
- imported `fs` from `cli.js` to confirm existence of custom template, otherwise throws an error
- tests are passing

I realize this means your authorship may no longer appear in the generated output, so I fully understand if you're not comfortable accepting this PR. 
Thanks!

