### PR TITLE
Ignore files command line flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Usage: diff2html [options] -- [diff args]
 | -o | --output | Output destination | `preview`, `stdout` | `preview` |
 | -u | --diffy | Upload to diffy.org | `browser`, `pbcopy`, `print` | |
 | -F | --file | Send output to file (overrides output option) | _[string]_ | |
-| --version | | Show version number | | |
+| -v | --version | | Show version number | | |
 | -h | --help | Show help | | |
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Usage: diff2html [options] -- [diff args]
 | -o | --output | Output destination | `preview`, `stdout` | `preview` |
 | -u | --diffy | Upload to diffy.org | `browser`, `pbcopy`, `print` | |
 | -F | --file | Send output to file (overrides output option) | _[string]_ | |
+| --ig | --ignore | Ignore particular files from the diff | _[string]_ | |
 | -v | --version | | Show version number | | |
 | -h | --help | Show help | | |
 
@@ -99,6 +100,8 @@ Examples:
     - `//diff2html-synchronisedScroll` - writes code to support selected scroll interaction, must be within a `<script>` block
     - `<!--diff2html-diff-->` - writes diff content to page
 
+`diff2htal --ig package-lock.json --ig yarn.lock`
+- Ignore `package-lock.json` and `yarn.lock` from the generated diff
 
 _NOTE_: notice the `--` in the examples
 
@@ -107,6 +110,10 @@ _NOTE_: notice the `--` in the examples
 This is a developer friendly project, all the contributions are welcome.
 To contribute just send a pull request with your changes following the guidelines described in `CONTRIBUTING.md`.
 I will try to review them as soon as possible.
+
+## Developing
+
+Make some changes and then `node src/main.js` 😉
 
 ## License
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -60,7 +60,7 @@
     var ignoreString = '';
 
     if (ignore) {
-      ignoreString = ignore.map(function (file) {
+      ignoreString = ignore.map(function(file) {
         return ' ":(exclude)' + file + '" ';
       }).join(' ');
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -44,19 +44,28 @@
 
   Diff2HtmlInterface.prototype._runGitDiff = function(gitArgsArr, ignore, callback) {
     var gitArgs;
+
     if (gitArgsArr.length && gitArgsArr[0]) {
       gitArgs = gitArgsArr.map(function(arg) {
-        return '"' + (ignore ? ':(exclude)' : '') + arg + '"'; // wrap parameters
+        return '"' + arg + '"'; // wrap parameters
       }).join(' ');
     } else {
       gitArgs = '-M -C HEAD';
     }
 
-    if (!ignore && gitArgs.indexOf('--no-color') < 0) {
+    if (gitArgs.indexOf('--no-color') < 0) {
       gitArgs += ' --no-color';
     }
 
-    var diffCommand = 'git diff ' + (ignore ? '--no-color ' : '') + gitArgs;
+    var ignoreString = '';
+
+    if (ignore) {
+      ignoreString = ignore.map(function (file) {
+        return ' ":(exclude)' + file + '" ';
+      }).join(' ');
+    }
+
+    var diffCommand = 'git diff ' + gitArgs + ignoreString;
 
     return callback(null, utils.runCmd(diffCommand));
   };

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,7 +26,7 @@
    * Input
    */
 
-  Diff2HtmlInterface.prototype.getInput = function getInput(inputType, inputArgs, callback) {
+  Diff2HtmlInterface.prototype.getInput = function getInput(inputType, inputArgs, ignore, callback) {
     var that = this;
     switch (inputType) {
       case 'file':
@@ -38,25 +38,26 @@
         break;
 
       default:
-        that._runGitDiff(inputArgs, callback);
+        that._runGitDiff(inputArgs, ignore, callback);
     }
   };
 
-  Diff2HtmlInterface.prototype._runGitDiff = function(gitArgsArr, callback) {
+  Diff2HtmlInterface.prototype._runGitDiff = function(gitArgsArr, ignore, callback) {
     var gitArgs;
     if (gitArgsArr.length && gitArgsArr[0]) {
       gitArgs = gitArgsArr.map(function(arg) {
-        return '"' + arg + '"'; // wrap parameters
+        return '"' + (ignore ? ':(exclude)' : '') + arg + '"'; // wrap parameters
       }).join(' ');
     } else {
       gitArgs = '-M -C HEAD';
     }
 
-    if (gitArgs.indexOf('--no-color') < 0) {
+    if (!ignore && gitArgs.indexOf('--no-color') < 0) {
       gitArgs += ' --no-color';
     }
 
-    var diffCommand = 'git diff ' + gitArgs;
+    var diffCommand = 'git diff ' + (ignore ? '--no-color ' : '') + gitArgs;
+
     return callback(null, utils.runCmd(diffCommand));
   };
 

--- a/src/main.js
+++ b/src/main.js
@@ -153,8 +153,10 @@ var argv = yargs.usage('Usage: diff2html [options] -- [diff args]')
   .example('diff2html -i file -- my-file-diff.diff', 'reading the input from a file')
   .example('diff2html -f json -o stdout -- -M HEAD~1', 'print json format to stdout')
   .example('diff2html -F my-pretty-diff.html -- -M HEAD~1', 'print to file')
-  .example('diff2html -ig -- package-lock.json yarn.lock', 'ignore two particular files when generating diff')
+  .example('diff2html -ig -- package-lock.json yarn.lock',
+    'ignore two particular files when generating the diff')
   .help('h')
+  .alias('v', 'version')
   .alias('h', 'help')
   .epilog('© 2014-' + currentYear + ' rtfpessoa\n' +
     'For more information, check out https://diff2html.xyz/\n' +

--- a/src/main.js
+++ b/src/main.js
@@ -137,12 +137,23 @@ var argv = yargs.usage('Usage: diff2html [options] -- [diff args]')
       type: 'string'
     }
   })
+  .options({
+    'ig': {
+      alias: 'ignore',
+      describe: 'ignore a file',
+      nargs: 1,
+      type: 'boolean',
+      choices: [true, false],
+      default: false
+    }
+  })
   .example('diff2html -s line -f html -d word -i command -o preview -- -M HEAD~1',
     'diff last commit, line by line, word comparison between lines,' +
     'previewed in the browser and input from git diff command')
   .example('diff2html -i file -- my-file-diff.diff', 'reading the input from a file')
   .example('diff2html -f json -o stdout -- -M HEAD~1', 'print json format to stdout')
   .example('diff2html -F my-pretty-diff.html -- -M HEAD~1', 'print to file')
+  .example('diff2html -ig -- package-lock.json yarn.lock', 'ignore two particular files when generating diff')
   .help('h')
   .alias('h', 'help')
   .epilog('© 2014-' + currentYear + ' rtfpessoa\n' +
@@ -193,4 +204,4 @@ function onOutput(err, output) {
   }
 }
 
-cli.getInput(argv.input, argv._, onInput);
+cli.getInput(argv.input, argv._, argv.ig, onInput);

--- a/src/main.js
+++ b/src/main.js
@@ -142,9 +142,7 @@ var argv = yargs.usage('Usage: diff2html [options] -- [diff args]')
       alias: 'ignore',
       describe: 'ignore a file',
       nargs: 1,
-      type: 'boolean',
-      choices: [true, false],
-      default: false
+      type: 'array'
     }
   })
   .example('diff2html -s line -f html -d word -i command -o preview -- -M HEAD~1',
@@ -153,7 +151,7 @@ var argv = yargs.usage('Usage: diff2html [options] -- [diff args]')
   .example('diff2html -i file -- my-file-diff.diff', 'reading the input from a file')
   .example('diff2html -f json -o stdout -- -M HEAD~1', 'print json format to stdout')
   .example('diff2html -F my-pretty-diff.html -- -M HEAD~1', 'print to file')
-  .example('diff2html -ig -- package-lock.json yarn.lock',
+  .example('diff2html --ig -- package-lock.json --ig yarn.lock',
     'ignore two particular files when generating the diff')
   .help('h')
   .alias('v', 'version')


### PR DESCRIPTION
This PR allows users to specify particular files they would like to exclude from the diff output. E.g.

`diff2html-cli -ig true -- package-lock.json`

This is particularly useful when a file will cause severe delays before displaying and pollute the diff view (as is the case with a large `package-lock.json` or `yarn.lock` file).

For discussion, see https://github.com/rtfpessoa/diff2html-cli/issues/36

This is not a very clean bit of code to filter out files, but it works before the _diff_ is generated, speeding up the diff generation. 

An unfortunate artifact of this code is no other git commands can be passed in other than a list of files to exclude from the diff.

I am very happy to refactor the code if @rtfpessoa has recommendations 🙇 