### PR TITLE
feature: Allow disabling hightlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Usage: diff2html [options] -- [diff args]
 | --- | --- | --- | --- | --- |
 | -s  | --style |  Output style | `line`, `side` | `line` |
 | --sc | --synchronisedScroll | Synchronised horizontal scroll | `true`, `false` | `true` |
+| --hc | --highlightCode | Highlight code | `true`, `false` | `true` |
 | --su | --summary | Show files summary | `closed`, `open`, `hidden` | `closed` |
 | --lm | --matching | Diff line matching type | `lines`, `words`, `none` | `none` |
 | --lmt | --matchWordsThreshold | Diff line matching word threshold | | `0.25` |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ function prepareHTML(diffHTMLContent: string, config: Configuration): string {
     .replace("<!--diff2html-js-ui-->", `<script>\n${jsUiContent}\n</script>`)
     .replace("//diff2html-fileListCloseable", `diff2htmlUi.fileListCloseable("#diff", ${config.showFilesOpen});`)
     .replace("//diff2html-synchronisedScroll", `diff2htmlUi.synchronisedScroll("#diff", ${config.synchronisedScroll});`)
+    .replace("//diff2html-highlightCode", config.highlightCode ? `diff2htmlUi.highlightCode("#diff");` : "")
     .replace("<!--diff2html-diff-->", diffHTMLContent);
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,6 +17,7 @@ export function parseArgv(argv: Argv): [Diff2Html.Options, Configuration] {
   const configuration: Configuration = {
     showFilesOpen: argv.summary === "open" || false,
     synchronisedScroll: argv.synchronisedScroll,
+    highlightCode: argv.highlightCode,
     formatType: argv.format,
     outputDestinationType: argv.output,
     outputDestinationFile: argv.file,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,10 @@ export type InputType = "file" | "command" | "stdin";
 export type OutputType = "preview" | "stdout";
 export type DiffyType = "browser" | "pbcopy" | "print";
 
-export interface Configuration {
+export type Configuration = {
   synchronisedScroll: boolean;
   showFilesOpen: boolean;
+  highlightCode: boolean;
   formatType: FormatType;
   outputDestinationType: OutputType;
   outputDestinationFile?: string;
@@ -16,4 +17,4 @@ export interface Configuration {
   diffyType?: DiffyType;
   htmlWrapperTemplate: string;
   ignore: string[];
-}
+};

--- a/src/yargs.ts
+++ b/src/yargs.ts
@@ -2,9 +2,10 @@ import * as yargs from "yargs";
 
 import { StyleType, SummaryType, LineMatchingType, FormatType, InputType, OutputType, DiffyType } from "./types";
 
-export interface Argv {
+export type Argv = {
   style: StyleType;
   synchronisedScroll: boolean;
+  highlightCode: boolean;
   summary: SummaryType;
   matching: LineMatchingType;
   matchWordsThreshold: number;
@@ -17,7 +18,7 @@ export interface Argv {
   htmlWrapperTemplate?: string;
   ignore?: string[];
   extraArguments: string[];
-}
+};
 
 export function setup(): Argv {
   const currentYear = new Date().getFullYear();
@@ -46,6 +47,14 @@ export function setup(): Argv {
       synchronisedScroll: {
         alias: "sc",
         describe: "Synchronised horizontal scroll",
+        type: "boolean",
+        default: true
+      }
+    })
+    .options({
+      highlightCode: {
+        alias: "hc",
+        describe: "Highlight Code",
         type: "boolean",
         default: true
       }
@@ -170,7 +179,7 @@ export function setup(): Argv {
     .strict(true)
     .recommendCommands().argv;
 
-  // HACK: Forcing conversions to better types here, since choices types are enforced in the beggining
+  // HACK: Forcing conversions to better types here, since choices types are enforced in the beginning
   return {
     ...argv,
     style: argv.style as StyleType,

--- a/template.html
+++ b/template.html
@@ -25,7 +25,7 @@
         var diff2htmlUi = new Diff2HtmlUI();
         //diff2html-fileListCloseable
         //diff2html-synchronisedScroll
-        diff2htmlUi.highlightCode("#diff");
+        //diff2html-highlightCode
       });
     </script>
   </head>


### PR DESCRIPTION
Fixes https://github.com/rtfpessoa/diff2html/issues/234 

The problem seems to be in highlight.js and in fact is not a problem.
Since you don't have filenames we cannot infer the language and it is being inferred as diff.

Since highlight.js is the last style applied there is not nice way around this.

I allowed removing the highlight and you can do it with:

`diff -u <(echo "First\nSecond") <(echo "First\n-->Second\nThird") | diff2html -i stdin --hc false`