### PR TITLE
Allow setting page title and header from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Usage: diff2html [ flags and/or options ] -- [git diff passthrough flags and opt
 |       | --maxLineSizeInBlockForComparison | Maximum number of characters of the bigger line in a block to apply comparison                     |                              | `200`     |
 |       | --maxLineLengthHighlight          | Maximum number of characters in a line to apply highlight                                          |                              | `10000`   |
 | --hwt | --htmlWrapperTemplate             | Path to custom template to be rendered when using the `html` output format                         | `[string]`                   |
+| -t    | --title                           | Page title for `html` output                                                                       | `[string]`                   |
 | -f    | --format                          | Output format                                                                                      | `html`, `json`               | `html`    |
 | -i    | --input                           | Diff input source                                                                                  | `file`, `command`, `stdin`   | `command` |
 | -o    | --output                          | Output destination                                                                                 | `preview`, `stdout`          | `preview` |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,11 +49,15 @@ function prepareHTML(diffHTMLContent: string, config: Configuration): string {
   const jsUiFilePath = path.resolve(diff2htmlPath, 'bundles', 'js', 'diff2html-ui-slim.min.js');
   const jsUiContent = utils.readFile(jsUiFilePath);
 
+  const pageTitle = config.pageTitle;
+  const pageHeader = config.pageHeader;
+
   /* HACK:
    *   Replace needs to receive a function as the second argument to perform an exact replacement.
    *     This will avoid the replacements from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter
    */
   return [
+    { searchValue: '<!--diff2html-title-->', replaceValue: pageTitle },
     { searchValue: '<!--diff2html-css-->', replaceValue: `<style>\n${cssContent}\n</style>` },
     { searchValue: '<!--diff2html-js-ui-->', replaceValue: `<script>\n${jsUiContent}\n</script>` },
     {
@@ -68,6 +72,7 @@ function prepareHTML(diffHTMLContent: string, config: Configuration): string {
       searchValue: '//diff2html-highlightCode',
       replaceValue: config.highlightCode ? `diff2htmlUi.highlightCode();` : '',
     },
+    { searchValue: '<!--diff2html-header-->', replaceValue: pageHeader },
     { searchValue: '<!--diff2html-diff-->', replaceValue: diffHTMLContent },
   ].reduce(
     (previousValue, replacement) =>

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -33,6 +33,8 @@ export function parseArgv(argv: Argv): [Diff2HtmlConfig, Configuration] {
     maxLineLengthHighlight: argv.maxLineLengthHighlight,
   };
 
+  const defaultPageTitle = 'Diff to HTML by rtfpessoa';
+  const defaultPageHeader = 'Diff to HTML by <a href="https://github.com/rtfpessoa">rtfpessoa</a>';
   const defaultWrapperTemplate = path.resolve(__dirname, '..', 'template.html');
   const configuration: Configuration = {
     showFilesOpen: argv.summary === 'open' || false,
@@ -44,6 +46,8 @@ export function parseArgv(argv: Argv): [Diff2HtmlConfig, Configuration] {
     inputSource: argv.input,
     diffyType: argv.diffy,
     htmlWrapperTemplate: argv.htmlWrapperTemplate || defaultWrapperTemplate,
+    pageTitle: argv.pageTitle || defaultPageTitle,
+    pageHeader: argv.pageTitle || defaultPageHeader,
     ignore: argv.ignore || [],
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,5 +17,7 @@ export type Configuration = {
   inputSource: InputType;
   diffyType?: DiffyType;
   htmlWrapperTemplate: string;
+  pageTitle: string;
+  pageHeader: string;
   ignore: string[];
 };

--- a/src/yargs.ts
+++ b/src/yargs.ts
@@ -31,6 +31,7 @@ export type Argv = {
   diffy?: DiffyType;
   file?: string;
   htmlWrapperTemplate?: string;
+  pageTitle?: string;
   ignore?: string[];
   extraArguments: string[];
 };
@@ -54,6 +55,7 @@ const defaults: Argv = {
   diffy: undefined,
   file: undefined,
   htmlWrapperTemplate: undefined,
+  pageTitle: undefined,
   extraArguments: [],
 };
 
@@ -205,6 +207,13 @@ export function setup(): Argv {
       nargs: 1,
       type: 'string',
       default: defaults.htmlWrapperTemplate,
+    })
+    .option('title', {
+      alias: 't',
+      describe: 'Page title for HTML output',
+      nargs: 1,
+      type: 'string',
+      default: defaults.pageTitle,
     })
     .option('ignore', {
       alias: 'ig',

--- a/template.html
+++ b/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Diff to HTML by rtfpessoa</title>
+    <title><!--diff2html-title--></title>
 
     <!--
       Diff to HTML (template.html)
@@ -26,7 +26,7 @@
     </script>
   </head>
   <body style="text-align: center; font-family: 'Source Sans Pro', sans-serif">
-    <h1>Diff to HTML by <a href="https://github.com/rtfpessoa">rtfpessoa</a></h1>
+    <h1><!--diff2html-header--></h1>
 
     <div id="diff">
       <!--diff2html-diff-->


### PR DESCRIPTION
Thanks for the great utility!

This PR adds a `-t`/`--title` flag that lets you change the page title and header in the HTML output. If no `-t` option is given, then the new output is unchanged from what it is currently.

Related issues: #33, #34.