### PR TITLE
feat: allow empty diff when 'renderNothingWhenEmpty' enabled

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ export async function main(): Promise<void> {
 
     const input = await cli.getInput(configuration.inputSource, argv.extraArguments, configuration.ignore);
 
-    if (!input) {
+    if (!input && !diff2htmlOptions.renderNothingWhenEmpty) {
       process.exitCode = 3;
       log.error('The input is empty. Try again.');
       yargs.help();


### PR DESCRIPTION
When '--renderNothingWhenEmpty' enabled, don't fail even if content is empty.

Closes: #141

--- 
```bash
$ diff -u README.md README.md | ./bin/diff2html --renderNothingWhenEmpty -i stdin -s side -F /tmp/diff.html && echo 'OK'
OK
$ echo $?
0
```

And empty diff content page is generated
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/40332842/206921218-1a59a451-f1cd-49bc-98a5-dbfe2a49ae31.png">
