### PR TITLE
feature: add colorScheme arg with updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Usage: diff2html [ flags and/or options ] -- [git diff passthrough flags and opt
 | --fct | --fileContentToggle               | Adds a viewed checkbox to toggle file content                                                      | `true`, `false`              | `true`    |
 | --sc  | --synchronisedScroll              | Synchronised horizontal scroll                                                                     | `true`, `false`              | `true`    |
 | --hc  | --highlightCode                   | Highlight code                                                                                     | `true`, `false`              | `true`    |
+| --cs  | --colorScheme                     | Color scheme                                                                                       | `auto`, `dark`, `light`      | `auto`    |
 | --su  | --summary                         | Show files summary                                                                                 | `closed`, `open`, `hidden`   | `closed`  |
 | -d    | --diffStyle                       | Diff style                                                                                         | `word`, `char`               | `word`    |
 | --lm  | --matching                        | Diff line matching type                                                                            | `lines`, `words`, `none`     | `none`    |

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "clipboardy": "^3.0.0",
-    "diff2html": "^3.4.19",
+    "diff2html": "^3.4.46",
     "node-fetch": "^3.3.2",
     "open": "^9.1.0",
     "yargs": "^17.6.0"

--- a/src/__tests__/main-tests.ts
+++ b/src/__tests__/main-tests.ts
@@ -50,6 +50,7 @@ describe('cli', () => {
         maxLineSizeInBlockForComparison: 200,
         outputFormat: 'line-by-line',
         renderNothingWhenEmpty: false,
+        colorScheme: 'auto',
       },
       {
         diffyType: undefined,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -34,6 +34,7 @@ export function parseArgv(argv: Argv): [Diff2HtmlConfig, Configuration] {
     renderNothingWhenEmpty: argv.renderNothingWhenEmpty,
     maxLineSizeInBlockForComparison: argv.maxLineSizeInBlockForComparison,
     maxLineLengthHighlight: argv.maxLineLengthHighlight,
+    colorScheme: argv.colorScheme,
   };
 
   const defaultPageTitle = 'Diff to HTML by rtfpessoa';

--- a/src/yargs.ts
+++ b/src/yargs.ts
@@ -118,6 +118,12 @@ export async function setup(): Promise<Argv> {
       type: 'boolean',
       default: defaults.highlightCode,
     })
+    .option('colorScheme', {
+      alias: 'cs',
+      describe: 'Color scheme of HTML output',
+      choices: choices.colorScheme,
+      default: defaults.colorScheme,
+    })
     .option('summary', {
       alias: 'su',
       describe: 'Show files summary',
@@ -233,12 +239,6 @@ export async function setup(): Promise<Argv> {
       describe: 'ignore a file',
       type: 'array',
       default: defaults.ignore,
-    })
-    .option('colorScheme', {
-      alias: 'cs',
-      describe: 'Color scheme of HTML output',
-      choices: choices.colorScheme,
-      default: defaults.colorScheme,
     })
     .example(
       'diff2html -s line -f html -d word -i command -o preview -- -M HEAD~1',

--- a/src/yargs.ts
+++ b/src/yargs.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+import { ColorSchemeType } from 'diff2html/lib/types.js';
 
 import {
   StyleType,
@@ -35,6 +36,7 @@ export type Argv = {
   title?: string;
   ignore?: string[];
   extraArguments: string[];
+  colorScheme: ColorSchemeType;
 };
 
 const defaults: Argv = {
@@ -59,6 +61,7 @@ const defaults: Argv = {
   htmlWrapperTemplate: undefined,
   title: undefined,
   extraArguments: [],
+  colorScheme: ColorSchemeType.AUTO,
 };
 
 type ArgvChoices = {
@@ -70,6 +73,7 @@ type ArgvChoices = {
   input: ReadonlyArray<InputType>;
   output: ReadonlyArray<OutputType>;
   diffy: ReadonlyArray<DiffyType>;
+  colorScheme: ReadonlyArray<ColorSchemeType>;
 };
 
 const choices: ArgvChoices = {
@@ -81,6 +85,7 @@ const choices: ArgvChoices = {
   input: ['file', 'command', 'stdin'],
   output: ['preview', 'stdout'],
   diffy: ['browser', 'pbcopy', 'print'],
+  colorScheme: [ColorSchemeType.AUTO, ColorSchemeType.DARK, ColorSchemeType.LIGHT],
 };
 
 export async function setup(): Promise<Argv> {
@@ -228,6 +233,12 @@ export async function setup(): Promise<Argv> {
       describe: 'ignore a file',
       type: 'array',
       default: defaults.ignore,
+    })
+    .option('colorScheme', {
+      alias: 'cs',
+      describe: 'Color scheme of HTML output',
+      choices: choices.colorScheme,
+      default: defaults.colorScheme,
     })
     .example(
       'diff2html -s line -f html -d word -i command -o preview -- -M HEAD~1',

--- a/template.html
+++ b/template.html
@@ -1,39 +1,36 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title><!--diff2html-title--></title>
 
-<head>
-  <meta charset="utf-8" />
-  <title><!--diff2html-title--></title>
-
-  <!--
+    <!--
       Diff to HTML (template.html)
       Author: rtfpessoa
     -->
 
-  <link rel="stylesheet" href="https://diff2html.xyz/demo.css?3b34d507487da05dfc0c" />
+    <link rel="stylesheet" href="https://diff2html.xyz/demo.css?3b34d507487da05dfc0c" />
 
-  <!--diff2html-css-->
+    <!--diff2html-css-->
 
-  <!--diff2html-js-ui-->
+    <!--diff2html-js-ui-->
 
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const targetElement = document.getElementById('diff');
-      const diff2htmlUi = new Diff2HtmlUI(targetElement);
-      //diff2html-fileListToggle
-      //diff2html-fileContentToggle
-      //diff2html-synchronisedScroll
-      //diff2html-highlightCode
-    });
-  </script>
-</head>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const targetElement = document.getElementById('diff');
+        const diff2htmlUi = new Diff2HtmlUI(targetElement);
+        //diff2html-fileListToggle
+        //diff2html-fileContentToggle
+        //diff2html-synchronisedScroll
+        //diff2html-highlightCode
+      });
+    </script>
+  </head>
+  <body style="text-align: center; font-family: 'Source Sans Pro', sans-serif">
+    <h1><!--diff2html-header--></h1>
 
-<body style="text-align: center; font-family: 'Source Sans Pro', sans-serif">
-  <h1><!--diff2html-header--></h1>
-
-  <div id="diff">
-    <!--diff2html-diff-->
-  </div>
-</body>
-
+    <div id="diff">
+      <!--diff2html-diff-->
+    </div>
+  </body>
 </html>

--- a/template.html
+++ b/template.html
@@ -1,36 +1,39 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title><!--diff2html-title--></title>
 
-    <!--
+<head>
+  <meta charset="utf-8" />
+  <title><!--diff2html-title--></title>
+
+  <!--
       Diff to HTML (template.html)
       Author: rtfpessoa
     -->
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/github.min.css" />
+  <link rel="stylesheet" href="https://diff2html.xyz/demo.css?3b34d507487da05dfc0c" />
 
-    <!--diff2html-css-->
+  <!--diff2html-css-->
 
-    <!--diff2html-js-ui-->
+  <!--diff2html-js-ui-->
 
-    <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        const targetElement = document.getElementById('diff');
-        const diff2htmlUi = new Diff2HtmlUI(targetElement);
-        //diff2html-fileListToggle
-        //diff2html-fileContentToggle
-        //diff2html-synchronisedScroll
-        //diff2html-highlightCode
-      });
-    </script>
-  </head>
-  <body style="text-align: center; font-family: 'Source Sans Pro', sans-serif">
-    <h1><!--diff2html-header--></h1>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const targetElement = document.getElementById('diff');
+      const diff2htmlUi = new Diff2HtmlUI(targetElement);
+      //diff2html-fileListToggle
+      //diff2html-fileContentToggle
+      //diff2html-synchronisedScroll
+      //diff2html-highlightCode
+    });
+  </script>
+</head>
 
-    <div id="diff">
-      <!--diff2html-diff-->
-    </div>
-  </body>
+<body style="text-align: center; font-family: 'Source Sans Pro', sans-serif">
+  <h1><!--diff2html-header--></h1>
+
+  <div id="diff">
+    <!--diff2html-diff-->
+  </div>
+</body>
+
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2331,15 +2331,15 @@ diff-sequences@^29.4.3:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
   integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
 
-diff2html@^3.4.19:
-  version "3.4.35"
-  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.35.tgz#75b83c0a7edd8b9521db9bebf8c657cd57f52d3e"
-  integrity sha512-+pKs1BrA7l8DAwY33awHyznE3iuTIo58xmINmDBUwGsnou2KvBoSr6dAa6AvQAM7SH+nGtuOKNXmxumgbGp/Pw==
+diff2html@^3.4.46:
+  version "3.4.46"
+  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.46.tgz#55344db9c9315787944357621a93659e92fcf8d9"
+  integrity sha512-z1SkrH7jDLfmsOYgwJmGiDTdzsbpw7p4vx084kNzeYqER+/Kqp8+v/L7lMsIWpFzlX3NaJDJna280Y/HFqel+Q==
   dependencies:
     diff "5.1.0"
     hogan.js "3.0.2"
   optionalDependencies:
-    highlight.js "11.6.0"
+    highlight.js "11.8.0"
 
 diff@5.1.0:
   version "5.1.0"
@@ -3158,10 +3158,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-highlight.js@11.6.0:
-  version "11.6.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.6.0.tgz#a50e9da05763f1bb0c1322c8f4f755242cff3f5a"
-  integrity sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==
+highlight.js@11.8.0:
+  version "11.8.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.8.0.tgz#966518ea83257bae2e7c9a48596231856555bb65"
+  integrity sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==
 
 hogan.js@3.0.2:
   version "3.0.2"


### PR DESCRIPTION
## Updates

Mostly just trying to add the `colorScheme` arg

* Updated `diff2html` version for updated args, etc.
* During visual testing, found the current demo page's CSS is _much_ better than what's hosted on cloudflare.
  Perhaps it would be better to lock into some version on that... not sure. Recommendation certainly welcome on that.
* Updated README file to reflect new `colorScheme` option